### PR TITLE
MUI Theme initialized

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
+    <meta name="description" content="Synco - Project managment application" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Inter:400,500,600,700,800&amp;display=swap"
+      rel="stylesheet"
     />
     <title>React App</title>
   </head>

--- a/src/theme/Theme.js
+++ b/src/theme/Theme.js
@@ -22,7 +22,7 @@ export const theme = (mode) =>
     ...CssBaseline,
     palette: {
       type: mode === 'light' ? 'light' : 'dark',
-      primary: mode === 'light' ? [lightPalette] : [darkPalette],
+      primary: mode === 'light' ? lightPalette : darkPalette,
       secondary: {
         main: '#EE7674',
       },

--- a/src/theme/Theme.js
+++ b/src/theme/Theme.js
@@ -1,0 +1,59 @@
+import { createTheme } from '@material-ui/core/styles';
+import { CssBaseline } from '@material-ui/core';
+
+const lightPalette = {
+  main: '#725cff',
+  background: '#FFFFFF',
+  middle: '#EDEBFF',
+  semi: '#C2B8FF',
+  contrastText: '#090023',
+};
+
+const darkPalette = {
+  main: '#725cff',
+  background: '#090023',
+  middle: '#240066',
+  semi: '#72659D',
+  contrastText: '#FFFFFF',
+};
+
+export const theme = (mode) =>
+  createTheme({
+    ...CssBaseline,
+    palette: {
+      type: mode === 'light' ? 'light' : 'dark',
+      primary: mode === 'light' ? [lightPalette] : [darkPalette],
+      secondary: {
+        main: '#EE7674',
+      },
+    },
+    typography: {
+      fontFamily: 'Inter',
+    },
+    shape: {
+      borderRadius: 4,
+    },
+    overrides: {
+      MuiButton: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+    props: {
+      MuiButton: {
+        disableRipple: true,
+        variant: 'contained',
+        color: 'primary',
+      },
+      MuiCheckbox: {
+        disableRipple: true,
+      },
+      MuiTextField: {
+        variant: 'outlined',
+        InputLabelProps: {
+          shrink: true,
+        },
+      },
+    },
+  });


### PR DESCRIPTION
_**This PR adds a Theme.js file that can be passed to a "ThemeProvider" and control the UI styling of the entire app.**_

**Changes:**

- Inter font import to index.html
- Theme.js file
- Normalize CSS with "CssBaseline"
- Light and dark primary palette
- Typography font family
- Shape border radius
- Overrides MuiButton
- Props for MuiButton, MuiCheckbox and MuiTextField